### PR TITLE
Support remarkable plugins and filtering the remarkable output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,3 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git-
 node_modules
-
-# Compiled files
-dist

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ var MyComponent = React.createClass({
         </Markdown>
 
         {/* Pass remarkable plugins to the `plugins` prop */}
-        {/* and filters to the `filters` prop */}
-        <Markdown source="**Markdown is awesome!**" plugins={[RemarkableEmoji]} filters={[twemoji.parse]} />
+        {/* and transforms to the `transforms` prop */}
+        <Markdown source="**Markdown is awesome!**" plugins={[RemarkableEmoji]} transforms={[twemoji.parse]} />
       </div>
     );
   }
@@ -54,7 +54,7 @@ Available props:
 - `source`  - Markdown source. You can also pass the source as children, which allows you to mix React components and Markdown.
 - `container` - Element to use as container. Defaults to `span`.
 - `plugins` - Array of remarkable plugins
-- `filters` - Array of string filters
+- `transforms` - Array of string transforms
 
 ## License
 MIT

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ npm install --save react-remarkable
 
 var React = require('react');
 var Markdown = require('react-remarkable');
+var RemarkableEmoji = require('remarkable-emoji');
+var twemoji = require('twemoji');
 
 var MyComponent = React.createClass({
 
@@ -34,6 +36,10 @@ var MyComponent = React.createClass({
 
           Pretty neat!
         </Markdown>
+
+        {/* Pass remarkable plugins to the `plugins` prop */}
+        {/* and filters to the `filters` prop */}
+        <Markdown source="**Markdown is awesome!**" plugins={[RemarkableEmoji]} filters={[twemoji.parse]} />
       </div>
     );
   }
@@ -47,6 +53,8 @@ Available props:
 - `options` - Hash of Remarkable options
 - `source`  - Markdown source. You can also pass the source as children, which allows you to mix React components and Markdown.
 - `container` - Element to use as container. Defaults to `span`.
+- `plugins` - Array of remarkable plugins
+- `filters` - Array of string filters
 
 ## License
 MIT

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,73 @@
+"use strict";
+
+var _interopRequire = function (obj) {
+  return obj && (obj["default"] || obj);
+};
+
+"use strict";
+
+var React = _interopRequire(require('react'));
+
+var Markdown = _interopRequire(require('remarkable'));
+
+var Remarkable = React.createClass({
+  displayName: "Remarkable",
+
+
+  getDefaultProps: function () {
+    return {
+      container: "div",
+      options: {},
+      plugins: [],
+      transforms: []
+    };
+  },
+
+  render: function () {
+    var Container = this.props.container;
+
+    return (React.createElement(Container, null, this.content()));
+  },
+
+  componentWillReceiveProps: function (nextProps) {
+    this.md = this.makeMarkdown(nextProps.options, nextProps.plugins);
+  },
+
+  content: function () {
+    var _this = this;
+    if (this.props.source) {
+      return React.createElement("span", {
+        dangerouslySetInnerHTML: { __html: this.renderMarkdown(this.props.source) }
+      });
+    } else {
+      return React.Children.map(this.props.children, function (child) {
+        if (typeof child === "string") {
+          return React.createElement("span", {
+            dangerouslySetInnerHTML: { __html: _this.renderMarkdown(child) }
+          });
+        } else {
+          return child;
+        }
+      });
+    }
+  },
+
+  makeMarkdown: function (options, plugins) {
+    return plugins.reduce(function (md, plugin) {
+      return md.use(plugin);
+    }, new Markdown(options));
+  },
+
+  renderMarkdown: function (source) {
+    if (!this.md) {
+      this.md = this.makeMarkdown(this.props.options, this.props.plugins);
+    }
+
+    return this.props.transforms.reduce(function (src, transform) {
+      return transform(src);
+    }, this.md.render(source));
+  }
+
+});
+
+module.exports = Remarkable;

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ var Remarkable = React.createClass({
     return {
       container: 'div',
       options: {},
+      plugins: []
     };
   },
 
@@ -23,8 +24,8 @@ var Remarkable = React.createClass({
   },
 
   componentWillUpdate(nextProps, nextState) {
-    if (nextProps.options !== this.props.options) {
-      this.md = new Markdown(nextProps.options);
+    if (nextProps.options !== this.props.options || nextProps.plugins !== this.props.plugins) {
+      this.md = this.makeMarkdown(nextProps.options, nextProps.plugins);
     }
   },
 
@@ -44,9 +45,15 @@ var Remarkable = React.createClass({
     }
   },
 
+  makeMarkdown(options, plugins) {
+    return plugins.reduce((md, plugin) => {
+      return md.use(plugin);
+    }, new Markdown(options));
+  },
+
   renderMarkdown(source) {
     if (!this.md) {
-      this.md = new Markdown(this.props.options);
+      this.md = this.makeMarkdown(this.props.options, this.props.plugins);
     }
 
     return this.md.render(source);

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,8 @@ var Remarkable = React.createClass({
     return {
       container: 'div',
       options: {},
-      plugins: []
+      plugins: [],
+      filters: []
     };
   },
 
@@ -56,7 +57,9 @@ var Remarkable = React.createClass({
       this.md = this.makeMarkdown(this.props.options, this.props.plugins);
     }
 
-    return this.md.render(source);
+    return this.props.filters.reduce((src, filter) => {
+      return filter(src);
+    }, this.md.render(source));
   }
 
 });

--- a/src/index.js
+++ b/src/index.js
@@ -24,10 +24,8 @@ var Remarkable = React.createClass({
     );
   },
 
-  componentWillUpdate(nextProps, nextState) {
-    if (nextProps.options !== this.props.options || nextProps.plugins !== this.props.plugins) {
-      this.md = this.makeMarkdown(nextProps.options, nextProps.plugins);
-    }
+  componentWillReceiveProps(nextProps) {
+    this.md = this.makeMarkdown(nextProps.options, nextProps.plugins);
   },
 
   content() {

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ var Remarkable = React.createClass({
       container: 'div',
       options: {},
       plugins: [],
-      filters: []
+      transforms: []
     };
   },
 
@@ -55,8 +55,8 @@ var Remarkable = React.createClass({
       this.md = this.makeMarkdown(this.props.options, this.props.plugins);
     }
 
-    return this.props.filters.reduce((src, filter) => {
-      return filter(src);
+    return this.props.transforms.reduce((src, transform) => {
+      return transform(src);
     }, this.md.render(source));
   }
 


### PR DESCRIPTION
For example, this would allow the use of `remarkable` plugins like `remarkable-emoji` and passing the rendered output through transforms like `twemoji`. The latter is useful because it is otherwise hard to change the output set in `dangerouslySetInnerHTML`.
