### PR TITLE
fix component

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ var Markdown = require('react-remarkable');
 
 var MyComponent = React.createClass({
 
-  render() {
+  render: function() {
     return (
       <div>
         {/* Pass Markdown source to the `source` prop */}
@@ -25,6 +25,7 @@ var MyComponent = React.createClass({
         {/* Or pass it as children */}
         {/* You can nest React components, too */}
         <Markdown>
+        {`
           ## Reasons React is great
 
           1. Server-side rendering
@@ -33,6 +34,7 @@ var MyComponent = React.createClass({
           <SomeOtherAmazingComponent />
 
           Pretty neat!
+        `}
         </Markdown>
       </div>
     );

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "url": "https://github.com/acdlite/react-remarkable.git"
   },
   "dependencies": {
-    "remarkable": "^1.4.1"
+    "remarkable": "^1.4.1",
+    "strip-indent": "^1.0.1"
   },
   "devDependencies": {
     "babel": "^5.1.13"

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from 'react';
+import strip from 'strip-indent';
 import Markdown from 'remarkable';
 
 var Remarkable = React.createClass({
@@ -49,7 +50,7 @@ var Remarkable = React.createClass({
       this.md = new Markdown(this.props.options);
     }
 
-    return this.md.render(source);
+    return this.md.render(strip(source));
   }
 
 });


### PR DESCRIPTION
Fixes the example on the home page and strips initial indentation so markdown can properly render.
