### PR TITLE
Pass props to the container-element

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ var Remarkable = React.createClass({
     var Container = this.props.container;
 
     return (
-      <Container>
+      <Container {...this.props}>
         {this.content()}
       </Container>
     );


### PR DESCRIPTION
I was really missing this little feature. Mostly because of styling (and I couldn't set a `className` on the container), but in some rare cases I'd want to add an `onClick` or `style` prop to the component itself. The contents of the container would be a string, so passing everything wouldn't be a problem IMHO.
