### PR TITLE
Don't update if unchanged

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,9 @@ class Remarkable extends React.Component {
     else if (this.props.source) {
       return this.props.source !== nextProps.source;
     }
+    else if (React.Children.count(this.props.children) === 1 && React.Children.count(nextProps.children) === 1) {
+      return (typeof this.props.children === 'string') && this.props.children !== nextProps.children;
+    }
     else {
       return true;
     }

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,10 @@ class Remarkable extends React.Component {
     container: PropTypes.string,
     options: PropTypes.object,
     source: PropTypes.string,
-    children: PropTypes.array
+    children: PropTypes.oneOfType([
+      PropTypes.arrayOf(PropTypes.node),
+      PropTypes.node
+    ])
   }
 
   static defaultProps = {

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,21 @@
 'use strict';
 
 import React from 'react';
+import PropTypes from 'prop-types';
 import Markdown from 'remarkable';
 
 class Remarkable extends React.Component {
+  static propTypes = {
+    container: PropTypes.string,
+    options: PropTypes.object,
+    source: PropTypes.string,
+    children: PropTypes.array
+  }
+
+  static defaultProps = {
+    container: 'div',
+    options: {}
+  }
 
   render() {
     var Container = this.props.container;

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,18 @@ class Remarkable extends React.Component {
     );
   }
 
+  shouldComponentUpdate(nextProps, nextState) {
+    if (nextProps.options !== this.props.options) {
+      return true;
+    }
+    else if (this.props.source) {
+      return this.props.source !== nextProps.source;
+    }
+    else {
+      return true;
+    }
+  }
+
   componentWillUpdate(nextProps, nextState) {
     if (nextProps.options !== this.props.options) {
       this.md = new Markdown(nextProps.options);


### PR DESCRIPTION
This reduces the number of cases in which the contents are re-rendered, specifically handling the `source` content case and the single unchanged string child case.
