### PR TITLE
`React.createClass` is deprecated

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,14 +3,13 @@
 import React from 'react';
 import Markdown from 'remarkable';
 
-var Remarkable = React.createClass({
-
+export default class Remarkable extends React.Component {
   getDefaultProps() {
     return {
       container: 'div',
       options: {},
     };
-  },
+  }
 
   render() {
     var Container = this.props.container;
@@ -20,13 +19,13 @@ var Remarkable = React.createClass({
         {this.content()}
       </Container>
     );
-  },
+  }
 
   componentWillUpdate(nextProps, nextState) {
     if (nextProps.options !== this.props.options) {
       this.md = new Markdown(nextProps.options);
     }
-  },
+  }
 
   content() {
     if (this.props.source) {
@@ -42,7 +41,7 @@ var Remarkable = React.createClass({
         }
       });
     }
-  },
+  }
 
   renderMarkdown(source) {
     if (!this.md) {
@@ -51,7 +50,4 @@ var Remarkable = React.createClass({
 
     return this.md.render(source);
   }
-
-});
-
-export default Remarkable;
+}


### PR DESCRIPTION
As of React 15.5.0, React.createClass is deprecated and cause a console warning.