### PR TITLE
Switch class declaration to es6 syntax

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,9 @@
 'use strict';
 
-import React from 'react';
+import React, { Component } from 'react';
 import Markdown from 'remarkable';
 
-var Remarkable = React.createClass({
-
-  getDefaultProps() {
-    return {
-      container: 'div',
-      options: {},
-    };
-  },
+class Remarkable extends Component {
 
   render() {
     var Container = this.props.container;
@@ -20,13 +13,13 @@ var Remarkable = React.createClass({
         {this.content()}
       </Container>
     );
-  },
+  }
 
   componentWillUpdate(nextProps, nextState) {
     if (nextProps.options !== this.props.options) {
       this.md = new Markdown(nextProps.options);
     }
-  },
+  }
 
   content() {
     if (this.props.source) {
@@ -42,7 +35,7 @@ var Remarkable = React.createClass({
         }
       });
     }
-  },
+  }
 
   renderMarkdown(source) {
     if (!this.md) {
@@ -52,6 +45,11 @@ var Remarkable = React.createClass({
     return this.md.render(source);
   }
 
-});
+};
+
+Remarkable.defaultProps = {
+  container: 'div',
+  options: {},
+};
 
 export default Remarkable;


### PR DESCRIPTION
This package shows a warning about using `React.createClass` in React 15. 

Tested locally.