### PR TITLE
pass non-remarkable props down to the container

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,10 +6,14 @@ import Markdown from 'remarkable';
 class Remarkable extends React.Component {
 
   render() {
-    var Container = this.props.container;
+    var { container: Container, ...props } = this.props;
+
+    ['children', 'options', 'source'].forEach(prop => {
+      delete props[prop];
+    });
 
     return (
-      <Container>
+      <Container {...props}>
         {this.content()}
       </Container>
     );


### PR DESCRIPTION
I saw PR #14 but the author is not responding to the requested changes so I decided to open this.

It passes all props that are not used by the `Remarkable` component itself down to the container. I kept the keyword `var` though I suppose this could be const.